### PR TITLE
StrawberryChocolate fix

### DIFF
--- a/3-flow_control_nested_statements/main.c
+++ b/3-flow_control_nested_statements/main.c
@@ -9,7 +9,7 @@ int main()
     float cost;
 
     // Declare string variables for all the flavours
-    char flavours[6][10];
+    char flavours[6][11]; // increasing the length of the array
     strcpy(flavours[1], "Vanilla");
     strcpy(flavours[2], "Strawberry");
     strcpy(flavours[3], "Chocolate");


### PR DESCRIPTION
The issue is that "Strawberry" has an extra character 'r' in it, which is causing the issue. Increasing the length of the string to 11 to accommodate the extra character fixes it.